### PR TITLE
Correcting the syntax for multiple Security Groups

### DIFF
--- a/cloud/amazon/ec2_elb_lb.py
+++ b/cloud/amazon/ec2_elb_lb.py
@@ -289,7 +289,7 @@ EXAMPLES = """
     module: ec2_elb_lb
     state: present
     name: 'New ELB'
-    security_group_ids: 'sg-123456, sg-67890'
+    security_group_ids: 'sg-123456,sg-67890'
     region: us-west-2
     subnets: 'subnet-123456,subnet-67890'
     purge_subnets: yes


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ec2_elb_lb
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The Document example for MULTIPLE Security Group IDS needs correction.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
Before
# Creates a ELB and assigns a list of subnets to it.
- local_action:
    module: ec2_elb_lb
    state: present
    name: 'New ELB'
    security_group_ids: 'sg-123456, sg-67890'
    region: us-west-2
    subnets: 'subnet-123456,subnet-67890'
    purge_subnets: yes
    listeners:
      - protocol: http
        load_balancer_port: 80
        instance_port: 80

After:
# Creates a ELB and assigns a list of subnets to it.
- local_action:
    module: ec2_elb_lb
    state: present
    name: 'New ELB'
    security_group_ids: 'sg-123456,sg-67890'
    region: us-west-2
    subnets: 'subnet-123456,subnet-67890'
    purge_subnets: yes
    listeners:
      - protocol: http
        load_balancer_port: 80
        instance_port: 80
```

When one adds:

security_group_ids: 'sg-123456, sg-67890' with a space in the middle python Boto will throw the following error:

boto.exception.BotoServerError: BotoServerError: 400 Bad Request
<ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
  <Error>
    <Type>Sender</Type>
    <Code>InvalidSecurityGroup</Code>
    <Message>Invalid id: &quot; sg-7a0f791e&quot; (expecting &quot;sg-...&quot;) (Service: AmazonEC2; Status Code: 400; Error Code: InvalidGroupId.Malformed; Request ID: 37efa87e-031c-423e-99b5-314473ffd3f8)</Message>
  </Error>
  <RequestId>1abec069-5916-11e6-bbd2-1bebbac09d49</RequestId>
</ErrorResponse>
